### PR TITLE
Visibility change

### DIFF
--- a/src/JMS/Parser/AbstractLexer.php
+++ b/src/JMS/Parser/AbstractLexer.php
@@ -30,7 +30,7 @@ abstract class AbstractLexer
 
     private $i;
     private $peek;
-    private $tokens;
+    protected $tokens;
 
     /**
      * Returns the name of the given token.


### PR DESCRIPTION
The $tokens property is used by public setInput. If you need to override setInput, with private $tokens wouldn't be accesible.
