### PR TITLE
Added extension point for the lexer

### DIFF
--- a/src/JMS/Parser/AbstractLexer.php
+++ b/src/JMS/Parser/AbstractLexer.php
@@ -30,7 +30,7 @@ abstract class AbstractLexer
 
     private $i;
     private $peek;
-    private $tokens;
+    protected $tokens;
 
     /**
      * Returns the name of the given token.


### PR DESCRIPTION
Making this protected means the Lexer can be extended (e.g. when you want to add multiple tokens for one value).